### PR TITLE
Proposal: make tokio optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/deepgram-devs/deepgram-rust-sdk"
 keywords = ["deepgram", "asr", "transcription", "ai", "speech-to-text"]
 categories = ["api-bindings", "multimedia::audio"]
 
+[features]
+default = ["live"]
+live = ["tokio", "tokio-tungstenite", "tokio-util"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -21,14 +25,18 @@ reqwest = { version = "0.11.10", default-features = false, features = ["json", "
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
-tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = { version = "0.17", features = ["rustls-tls-webpki-roots"] }
-tokio-util = { version = "0.7.1", features = ["codec", "io"] }
+tokio = { version = "1", features = ["full"], optional = true }
+tokio-tungstenite = { version = "0.17", features = ["rustls-tls-webpki-roots"], optional = true }
+tokio-util = { version = "0.7.1", features = ["codec", "io"], optional = true }
 tungstenite = "0.17"
 url = "2"
 uuid = { version = "1", features = ["serde"] }
 
 [dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = { version = "0.17", features = ["rustls-tls-webpki-roots"] }
+tokio-util = { version = "0.7.1", features = ["codec", "io"] }
+
 pkg-config = "0.3.27"
 cpal = "0.13"
 crossbeam = "0.8"

--- a/examples/microphone_stream.rs
+++ b/examples/microphone_stream.rs
@@ -87,6 +87,12 @@ fn microphone_as_stream() -> FuturesReceiver<Result<Bytes, RecvError>> {
     async_rx
 }
 
+#[cfg(not(feature = "tokio"))]
+fn main() {
+    println!("This example requires the `tokio` feature");
+}
+
+#[cfg(feature = "tokio")]
 #[tokio::main]
 async fn main() -> Result<(), DeepgramError> {
     let dg = Deepgram::new(env::var("DEEPGRAM_API_KEY").unwrap());

--- a/examples/simple_stream.rs
+++ b/examples/simple_stream.rs
@@ -5,6 +5,12 @@ use futures::stream::StreamExt;
 
 use deepgram::{Deepgram, DeepgramError};
 
+#[cfg(not(feature = "tokio"))]
+fn main() {
+    println!("This example requires the `tokio` feature");
+}
+
+#[cfg(feature = "tokio")]
 #[tokio::main]
 async fn main() -> Result<(), DeepgramError> {
     let dg = Deepgram::new(env::var("DEEPGRAM_API_KEY").unwrap());

--- a/src/transcription/live.rs
+++ b/src/transcription/live.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "tokio")]
 // TODO: Remove this lint
 // Currently not documented because interface of this module is still changing
 #![allow(missing_docs)]


### PR DESCRIPTION
It should be possible to use the library without picking a runtime.

The live feature would take some work to uncouple from tokio and tungstenite, so I left it under a default flag for now.