### PR TITLE
Prepare for 0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/deepgram-devs/deepgram-rust-sdk/compare/0.6.1...HEAD)
+## [Unreleased](https://github.com/deepgram/deepgram-rust-sdk/compare/0.6.2...HEAD)
 
-## [0.6.1](https://github.com/deepgram-devs/deepgram-rust-sdk/compare/0.6.0...0.6.1)
+- Update documentation to point to 
+  [deepgram/deepgram-rust-sdk](https://github.com/deepgram/deepgram-rust-sdk).
+
+## [0.6.1](https://github.com/deepgram/deepgram-rust-sdk/compare/0.6.1...0.6.2)
+
+- 
+## [0.6.1](https://github.com/deepgram/deepgram-rust-sdk/compare/0.6.0...0.6.1)
 
 - Implement `From<String>` for `Model`, `Language`, and `Redact`
 - Add callback support to websocket connections.
 
-## [0.6.0](https://github.com/deepgram-devs/deepgram-rust-sdk/compare/0.5.0...0.6.0) - 2024-08-08
+## [0.6.0](https://github.com/deepgram/deepgram-rust-sdk/compare/0.5.0...0.6.0) - 2024-08-08
 
 ### Migrating from 0.4.0 -> 0.6.0
 
@@ -131,14 +137,14 @@ Some Enums have changed and may need to be updated
 - custom_topics
 - custom_topic_mode
 
-## [0.5.0](https://github.com/deepgram-devs/deepgram-rust-sdk/compare/0.4.0...0.5.0) - 2024-07-08
+## [0.5.0](https://github.com/deepgram/deepgram-rust-sdk/compare/0.4.0...0.5.0) - 2024-07-08
 
 - Deprecate tiers and add explicit support for all currently available models.
 - Expand language enum to include all currently-supported languages.
 - Add (default on) feature flags for live and prerecorded transcription.
 - Support arbitrary query params in transcription options.
 
-## [0.4.0](https://github.com/deepgram-devs/deepgram-rust-sdk/compare/0.3.0...0.4.0) - 2023-11-01
+## [0.4.0](https://github.com/deepgram/deepgram-rust-sdk/compare/0.3.0...0.4.0) - 2023-11-01
 
 ### Added
 - `detect_language` option.
@@ -147,7 +153,7 @@ Some Enums have changed and may need to be updated
 - Remove generic from `Deepgram` struct.
 - Upgrade dependencies: `tungstenite`, `tokio-tungstenite`, `reqwest`.
 
-## [0.3.0](https://github.com/deepgram-devs/deepgram-rust-sdk/compare/0.2.1...0.3.0) - 2023-07-26
+## [0.3.0](https://github.com/deepgram/deepgram-rust-sdk/compare/0.2.1...0.3.0) - 2023-07-26
 
 ### Added
 - Derive `Serialize` for all response types.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 **NOTICE**: *For the majority of situations, please use the dev branch as the base for your pull request.
 We only update the main branch when we release a new version of the package.
-[More info](https://github.com/deepgram-devs/deepgram-rust-sdk/wiki/Branches).*
+[More info](https://github.com/deepgram/deepgram-rust-sdk/wiki/Branches).*
 
 # Contributing Guidelines
 
@@ -46,4 +46,4 @@ continue to add more commits to the branch you have sent the Pull Request from.
 3. Create a new branch and check it out.
 4. Make your changes and commit them. (Did the tests pass? No linting errors?)
 5. Push your new branch to your fork.
-6. Open a Pull Request from your new branch to the [`deepgram-devs/deepgram-rust-sdk`](https://github.com/deepgram-devs/deepgram-rust-sdk)'s `dev` branch.
+6. Open a Pull Request from your new branch to the [`deepgram/deepgram-rust-sdk`](https://github.com/deepgram/deepgram-rust-sdk)'s `dev` branch.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepgram"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Deepgram <developers@deepgram.com>"]
 edition = "2021"
 description = "Official Rust SDK for Deepgram's automated speech recognition APIs."

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cargo build
 We love to hear from you so if you have questions, comments or find a bug in the
 project, let us know! You can either:
 
-- [Open an issue in this repository](https://github.com/deepgram-devs/deepgram-rust-sdk/issues/new)
+- [Open an issue in this repository](https://github.com/deepgram/deepgram-rust-sdk/issues/new)
 - [Join the Deepgram Github Discussions Community](https://github.com/orgs/deepgram/discussions)
 - [Join the Deepgram Discord Community](https://discord.gg/xWRaCDBtW4)
 


### PR DESCRIPTION
Update crate to 0.6.2 and remove references to deepgram-devs github org
