### PR TITLE
Set host header based on host URL instead of hardcoding it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepgram"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["Deepgram <developers@deepgram.com>"]
 edition = "2021"
 description = "Community Rust SDK for Deepgram's automated speech recognition APIs."

--- a/examples/speak/rest/text_to_speech_to_stream.rs
+++ b/examples/speak/rest/text_to_speech_to_stream.rs
@@ -45,11 +45,13 @@ impl Linear16AudioSource {
 impl Buf for Linear16AudioSource {
     type Sample = i16;
 
-    type Channel<'this> = LinearChannel<'this, i16>
+    type Channel<'this>
+        = LinearChannel<'this, i16>
     where
         Self: 'this;
 
-    type IterChannels<'this> = std::vec::IntoIter<LinearChannel<'this, i16>>
+    type IterChannels<'this>
+        = std::vec::IntoIter<LinearChannel<'this, i16>>
     where
         Self: 'this;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ impl<'a> From<&'a Deepgram> for Speak<'a> {
     }
 }
 
-impl<'a> Transcription<'a> {
+impl Transcription<'_> {
     /// Expose a method to access the inner `Deepgram` reference if needed.
     pub fn deepgram(&self) -> &Deepgram {
         self.0

--- a/src/listen/websocket.rs
+++ b/src/listen/websocket.rs
@@ -653,13 +653,14 @@ pub struct WebsocketHandle {
 impl<'a> WebsocketHandle {
     async fn new(builder: WebsocketBuilder<'a>) -> Result<WebsocketHandle> {
         let url = builder.as_url()?;
+        let host = url.host_str().ok_or(DeepgramError::InvalidUrl)?;
 
         let request = {
             let http_builder = Request::builder()
                 .method("GET")
                 .uri(url.to_string())
                 .header("sec-websocket-key", client::generate_key())
-                .header("host", "twilio-wrapper.deepgram.com")
+                .header("host", host)
                 .header("connection", "upgrade")
                 .header("upgrade", "websocket")
                 .header("sec-websocket-version", "13");

--- a/src/listen/websocket.rs
+++ b/src/listen/websocket.rs
@@ -659,7 +659,7 @@ impl<'a> WebsocketHandle {
                 .method("GET")
                 .uri(url.to_string())
                 .header("sec-websocket-key", client::generate_key())
-                .header("host", "api.deepgram.com")
+                .header("host", "twilio-wrapper.deepgram.com")
                 .header("connection", "upgrade")
                 .header("upgrade", "websocket")
                 .header("sec-websocket-version", "13");

--- a/src/listen/websocket.rs
+++ b/src/listen/websocket.rs
@@ -131,7 +131,6 @@ impl Transcription<'_> {
     ///
     /// assert_eq!(&builder.urlencoded().unwrap(), "model=nova-2&detect_language=true&no_delay=true")
     /// ```
-
     pub fn stream_request_with_options(&self, options: Options) -> WebsocketBuilder<'_> {
         WebsocketBuilder {
             deepgram: self.0,
@@ -166,7 +165,7 @@ impl Transcription<'_> {
     }
 }
 
-impl<'a> WebsocketBuilder<'a> {
+impl WebsocketBuilder<'_> {
     /// Return the options in urlencoded format. If serialization would
     /// fail, this will also return an error.
     ///


### PR DESCRIPTION
Attempting to make a streaming listen request to my hosted server was failing because the SDK was setting the `host` header as `api.deepgram.com`, but the Deepgram instance I was running lived at a different domain. This PR sets the `host` header to whichever host is actually receiving the request.