### PR TITLE
Update websocket.rs

### DIFF
--- a/src/listen/websocket.rs
+++ b/src/listen/websocket.rs
@@ -366,7 +366,7 @@ impl<'a> WebsocketBuilder<'a> {
         let mut is_done = false;
         let request_id = handle.request_id();
         tokio::task::spawn(async move {
-            let mut handle = handle.fuse();
+            let mut handle = handle.as_stream().fuse();
             let mut tx = tx;
             let mut stream = stream.fuse();
             


### PR DESCRIPTION
Resolves potential issue with select_biased and fuse() inside loop

```
Futures and streams which are not already fused can be fused using the .fuse() method. Note, though, that fusing a future or stream directly in the call to select_biased! will not be enough to prevent it from being polled after completion if the select_biased! call is in a loop, so when select_biased!ing in a loop, users should take care to fuse() outside of the loop.
```

Ref: https://docs.rs/futures-util/latest/futures_util/macro.select_biased.html#:~:text=call%20is%20in%20a%20loop,every%20branch%20in%20a%20select_biased!