### PR TITLE
Fix select biased by fusing streams outside loop

### DIFF
--- a/src/listen/websocket.rs
+++ b/src/listen/websocket.rs
@@ -567,7 +567,7 @@ async fn run_worker(
                     }
                 }
             }
-            message = message_rx.next().fuse() => {
+            message = message_rx.next() => {
                 // eprintln!("<worker> received message: {message:?}, {is_open:?}");
                 if is_open {
                     match message {

--- a/src/listen/websocket.rs
+++ b/src/listen/websocket.rs
@@ -462,7 +462,7 @@ macro_rules! send_message {
 async fn run_worker(
     ws_stream: WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>,
     mut message_tx: Sender<WsMessage>,
-    message_rx: Receiver<WsMessage>,
+    mut message_rx: Receiver<WsMessage>,
     mut response_tx: Sender<Result<StreamResponse>>,
     keep_alive: bool,
 ) -> Result<()> {
@@ -472,7 +472,6 @@ async fn run_worker(
     let mut ws_stream_recv = ws_stream_recv.fuse();
     let mut is_open: bool = true;
     let mut last_sent_message = tokio::time::Instant::now();
-    let mut message_rx = message_rx.fuse();
     loop {
         // eprintln!("<worker> loop");
         let sleep = tokio::time::sleep_until(last_sent_message + Duration::from_secs(3));
@@ -648,7 +647,7 @@ impl Deref for Audio {
 #[derive(Debug)]
 pub struct WebsocketHandle {
     message_tx: Sender<WsMessage>,
-    response_rx: futures::stream::Fuse<Receiver<Result<StreamResponse>>>,
+    response_rx: Receiver<Result<StreamResponse>>,
     request_id: Uuid,
 }
 
@@ -706,7 +705,7 @@ impl WebsocketHandle {
 
         Ok(WebsocketHandle {
             message_tx,
-            response_rx: response_rx.fuse(),
+            response_rx,
             request_id,
         })
     }


### PR DESCRIPTION
- Fuse streams properly in select_biased in `WebsocketHandle::stream` and `run_worker`.

Based on [the documentation for select_biased](https://docs.rs/futures-util/latest/futures_util/macro.select_biased.html#:~:text=call%20is%20in%20a%20loop,every%20branch%20in%20a%20select_biased!), as reported by a customer, streams used in select_biased need to be fused on the stream, not the future, and futures polled more than once need to be fused outside the loop.  Otherwise, the inner future will need to be re-polled each time to determine whether fusing needs to happen, which causes a busy loop (at best) in the case of Streams, and a possible panic for Futures.
