### PR TITLE
Solve result too large issue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub enum DeepgramError {
     #[cfg(feature = "listen")]
     /// Something went wrong with WS.
     #[error("Something went wrong with WS: {0}")]
-    WsError(#[from] TungsteniteError),
+    WsError(#[from] Box<TungsteniteError>),
 
     /// Something went wrong during serialization/deserialization.
     #[error("Something went wrong during json serialization/deserialization: {0}")]
@@ -182,6 +182,13 @@ pub enum DeepgramError {
     /// A Deepgram API server response was not in the expected format.
     #[error("The Deepgram API server response was not in the expected format: {0}")]
     UnexpectedServerResponse(anyhow::Error),
+}
+
+#[cfg(feature = "listen")]
+impl From<TungsteniteError> for DeepgramError {
+    fn from(err: TungsteniteError) -> Self {
+        Self::from(Box::new(err))
+    }
 }
 
 #[cfg_attr(not(feature = "listen"), allow(unused))]


### PR DESCRIPTION
Error code is too big because TunsgteniteError is too large this patch proposes using a Box to contain reducing the type error using the heap instead of the stack. I've tested against our code that makes use of this error and it does not seems to affect compilation.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210640783954837