### PR TITLE
feat: add support for token-based authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 your_output_file.wav
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -15,10 +15,38 @@ This SDK implements the Deepgram API found at [https://developers.deepgram.com](
 
 Documentation and examples can be found on our [Docs.rs page](https://docs.rs/deepgram/latest/deepgram/).
 
-## Getting an API Key
+## Quick Start
+
+Check out the [examples folder](./examples/) for practical code examples showing how to use the SDK.
+
+## Authentication
 
 🔑 To access the Deepgram API you will need a [free Deepgram API Key](https://console.deepgram.com/signup?jump=keys).
 
+There are two ways to authenticate with the Deepgram API:
+
+1.  **API Key**: This is the simplest method. You can get a free API key from the
+    [Deepgram Console](https://console.deepgram.com/signup?jump=keys).
+
+    ```rust
+    use deepgram::Deepgram;
+
+    let dg = Deepgram::new("YOUR_DEEPGRAM_API_KEY");
+    ```
+
+2.  **Temporary Tokens**: If you are building an application where you need to
+    grant temporary access to the Deepgram API, you can use temporary tokens.
+    This is useful for client-side applications where you don't want to expose
+    your API key.
+
+    You can create temporary tokens using the Deepgram API. Learn more about
+    [token-based authentication](https://developers.deepgram.com/guides/fundamentals/token-based-authentication).
+
+    ```rust
+    use deepgram::Deepgram;
+
+    let dg = Deepgram::with_temp_token("YOUR_TEMPORARY_TOKEN");
+    ```
 
 ## Current Status
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ impl Deepgram {
         let authorization_header = {
             let mut header = HeaderMap::new();
             if let Some(api_key) = &api_key {
-                if let Ok(value) = HeaderValue::from_str(&format!("Token {}", api_key)) {
+                if let Ok(value) = HeaderValue::from_str(&format!("Bearer {}", api_key)) {
                     header.insert("Authorization", value);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,8 @@ impl Transcription<'_> {
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct RedactedString(pub String);
+/// A string wrapper that redacts its contents when formatted with `Debug`.
+pub struct RedactedString(pub String);
 
 impl fmt::Debug for RedactedString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/listen/websocket.rs
+++ b/src/listen/websocket.rs
@@ -667,7 +667,9 @@ impl WebsocketHandle {
                 .header("sec-websocket-version", "13");
 
             let builder = if let Some(api_key) = builder.deepgram.api_key.as_deref() {
-                http_builder.header("authorization", format!("Token {}", api_key))
+                http_builder.header("authorization", format!("Bearer {}", api_key))
+            // TODO: make using temp tokens an option https://developers.deepgram.com/docs/token-based-authentication
+            // API Keys need to be sent as "Token dg_asdasdfjhsadjas" whereas temp tokens need to be sent as "Bearer dg_asdasdfjhsadjas"
             } else {
                 http_builder
             };

--- a/src/listen/websocket.rs
+++ b/src/listen/websocket.rs
@@ -667,11 +667,7 @@ impl WebsocketHandle {
                 .header("sec-websocket-version", "13");
 
             let builder = if let Some(auth) = &builder.deepgram.auth {
-                if let Some(header_value) = auth.header_value() {
-                    http_builder.header("authorization", header_value)
-                } else {
-                    http_builder
-                }
+                http_builder.header("authorization", auth.header_value())
             } else {
                 http_builder
             };

--- a/src/listen/websocket.rs
+++ b/src/listen/websocket.rs
@@ -666,10 +666,12 @@ impl WebsocketHandle {
                 .header("upgrade", "websocket")
                 .header("sec-websocket-version", "13");
 
-            let builder = if let Some(api_key) = builder.deepgram.api_key.as_deref() {
-                http_builder.header("authorization", format!("Bearer {}", api_key))
-            // TODO: make using temp tokens an option https://developers.deepgram.com/docs/token-based-authentication
-            // API Keys need to be sent as "Token dg_asdasdfjhsadjas" whereas temp tokens need to be sent as "Bearer dg_asdasdfjhsadjas"
+            let builder = if let Some(auth) = &builder.deepgram.auth {
+                if let Some(header_value) = auth.header_value() {
+                    http_builder.header("authorization", header_value)
+                } else {
+                    http_builder
+                }
             } else {
                 http_builder
             };


### PR DESCRIPTION
## Proposed changes

This PR adds proper support for temporary token authentication to the Deepgram Rust SDK. I'm working on a client-side application, and I was surprised to discover that the SDK only supported API key authentication with the "Token" prefix, thus not supporting [token-based auth](https://developers.deepgram.com/guides/fundamentals/token-based-authentication).

- **API Keys**: Should use the `Token` prefix (e.g., `Token dg_xxx`)
- **Temporary Tokens**: Should use the `Bearer` prefix (e.g., `Bearer dg_xxx`)

The existing implementation incorrectly used "Token" for all authentication, which worked for API keys but was wrong for temporary tokens.

**Changes:**

There are no breaking changes to current apps.

- Added `AuthMethod` enum to distinguish between API keys and temporary tokens
- Updated `Deepgram` struct to use the new authentication system (by default it'll still use API keys)
- Added `Deepgram::with_temp_token()` constructor for temporary token authentication
- Use new auth logic in websocket
- Added authentication documentation to README
- Added tests for the new authentication logic

All existing tests pass, and the change is backwards compatible for API usage patterns.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) doc
- [x] I have added tests and/or examples that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210640783954837