### PR TITLE
Fix typo in serialization for Container::None

### DIFF
--- a/src/speak/options.rs
+++ b/src/speak/options.rs
@@ -144,7 +144,7 @@ impl Container {
         match self {
             Container::Wav => "wav",
             Container::Ogg => "ogg",
-            Container::None => "nonne",
+            Container::None => "none",
             Container::CustomContainer(container) => container,
         }
     }


### PR DESCRIPTION


## Proposed changes

* Fix serialization bug that causes an API error for `Container::None`

## Types of changes

<!-- What types of changes does your code introduce to the Deepgram Rust SDK? -->

<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

<!-- You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

<!-- Put an `x` in the boxes that apply. -->
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) doc
- [ ] I have added tests and/or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


