### PR TITLE
Language support added to batch response

### DIFF
--- a/src/common/batch_response.rs
+++ b/src/common/batch_response.rs
@@ -59,6 +59,9 @@ pub struct ListenMetadata {
 
     #[allow(missing_docs)]
     pub channels: usize,
+
+    #[allow(missing_docs)]
+    pub language: Option<String>,
 }
 
 /// Transcription results.
@@ -336,6 +339,10 @@ pub struct ResultAlternative {
 
     #[allow(missing_docs)]
     pub entities: Option<Vec<Entity>>,
+    
+    #[allow(missing_docs)]
+    #[serde(default)]
+    pub languages: Vec<String>,
 }
 
 /// A single transcribed word.

--- a/src/common/batch_response.rs
+++ b/src/common/batch_response.rs
@@ -339,7 +339,7 @@ pub struct ResultAlternative {
 
     #[allow(missing_docs)]
     pub entities: Option<Vec<Entity>>,
-    
+
     #[allow(missing_docs)]
     #[serde(default)]
     pub languages: Vec<String>,


### PR DESCRIPTION
## Proposed changes

Adds support for Deepgram’s multi-language transcription in the Rust SDK by including language metadata in response types:

ResultAlternative.languages: Vec<String>
Captures detected languages per alternative. Uses #[serde(default)] to avoid deserialization errors when absent.

Word.language: Option<String>
Adds optional per-word language info for finer-grained multilingual analysis.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) doc
- [x] I have added tests and/or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Tested by creating transcripts with and without the proposed changes, using both Language::multi and other language settings. Verified that:

Existing functionality remains unaffected

language and languages fields are correctly populated when expected