### PR TITLE
feat(listen): expose WebSocket connection diagnostics (Tier 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,11 @@ path = "examples/transcription/websocket/simple_stream.rs"
 required-features = ["listen"]
 
 [[example]]
+name = "connection_diagnostics"
+path = "examples/transcription/websocket/connection_diagnostics.rs"
+required-features = ["listen"]
+
+[[example]]
 name = "callback_stream"
 path = "examples/transcription/websocket/callback_stream.rs"
 required-features = ["listen"]

--- a/examples/transcription/websocket/connection_diagnostics.rs
+++ b/examples/transcription/websocket/connection_diagnostics.rs
@@ -1,0 +1,63 @@
+//! Log WebSocket connection diagnostics for a live transcription request.
+//!
+//! Once the WebSocket upgrade completes, `connection_info()` exposes connection
+//! metadata (request ID, final URL, local/peer socket addresses, and total
+//! connect-plus-upgrade duration). Emitting it as a single JSONL record makes it
+//! easy to collect from production traffic and share with Deepgram when
+//! troubleshooting connectivity or latency.
+
+use std::env;
+use std::time::Duration;
+
+use futures::stream::StreamExt;
+use serde_json::json;
+
+use deepgram::{
+    common::options::{Encoding, Endpointing, Language, Options},
+    Deepgram, DeepgramError,
+};
+
+static PATH_TO_FILE: &str = "examples/audio/bueller.wav";
+static AUDIO_CHUNK_SIZE: usize = 3174;
+static FRAME_DELAY: Duration = Duration::from_millis(16);
+
+#[tokio::main]
+async fn main() -> Result<(), DeepgramError> {
+    let deepgram_api_key =
+        env::var("DEEPGRAM_API_KEY").expect("DEEPGRAM_API_KEY environmental variable");
+
+    let dg_client = Deepgram::new(&deepgram_api_key)?;
+
+    let options = Options::builder()
+        .smart_format(true)
+        .language(Language::en_US)
+        .build();
+
+    let mut results = dg_client
+        .transcription()
+        .stream_request_with_options(options)
+        .keep_alive()
+        .encoding(Encoding::Linear16)
+        .sample_rate(44100)
+        .channels(2)
+        .endpointing(Endpointing::CustomDurationMs(300))
+        .file(PATH_TO_FILE, AUDIO_CHUNK_SIZE, FRAME_DELAY)
+        .await?;
+
+    // Emit connection diagnostics as a single JSONL record.
+    let info = results.connection_info();
+    let record = json!({
+        "request_id": info.request_id.to_string(),
+        "url": info.url,
+        "local_addr": info.local_addr.map(|addr| addr.to_string()),
+        "peer_addr": info.peer_addr.map(|addr| addr.to_string()),
+        "connect_duration_ms": info.connect_duration.as_millis(),
+    });
+    println!("{record}");
+
+    while let Some(result) = results.next().await {
+        println!("got: {result:?}");
+    }
+
+    Ok(())
+}

--- a/src/listen/connection.rs
+++ b/src/listen/connection.rs
@@ -1,0 +1,67 @@
+//! Diagnostics describing an established live WebSocket connection.
+//!
+//! These types surface connection metadata that is useful when logging or
+//! troubleshooting live streaming requests -- for example, correlating a
+//! Deepgram request ID with the local and remote socket addresses actually used
+//! by a production connection.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tokio_tungstenite::MaybeTlsStream;
+use uuid::Uuid;
+
+/// Metadata captured from a successfully established live WebSocket connection.
+///
+/// This is available on both the low-level handle and the high-level stream for
+/// live speech-to-text and Flux via their `connection_info()` accessors.
+///
+/// It only describes connections that completed the WebSocket upgrade: a
+/// connection that fails or is cancelled (for example, by a caller-side connect
+/// timeout) before the upgrade completes never produces a
+/// `WebSocketConnectionInfo`.
+#[derive(Debug, Clone)]
+pub struct WebSocketConnectionInfo {
+    /// The Deepgram request ID parsed from the `dg-request-id` upgrade header.
+    pub request_id: Uuid,
+
+    /// The final request URL used for the connection, including model and
+    /// feature query parameters. Authentication is sent as a header and is not
+    /// part of this URL.
+    pub url: String,
+
+    /// The local (source) socket address of the underlying TCP connection, if it
+    /// could be determined.
+    pub local_addr: Option<SocketAddr>,
+
+    /// The resolved peer (destination) socket address of the underlying TCP
+    /// connection, if it could be determined.
+    pub peer_addr: Option<SocketAddr>,
+
+    /// The total time taken to establish the connection, measured around the
+    /// connect-and-upgrade call (DNS resolution, TCP connect, TLS handshake, and
+    /// WebSocket upgrade combined).
+    pub connect_duration: Duration,
+}
+
+/// Extract the local and peer socket addresses from an established WebSocket
+/// stream's underlying TCP socket.
+///
+/// Returns `(None, None)` if the addresses can't be read (for example, an
+/// unrecognized transport variant).
+pub(crate) fn socket_addrs(
+    stream: &MaybeTlsStream<tokio::net::TcpStream>,
+) -> (Option<SocketAddr>, Option<SocketAddr>) {
+    let tcp = match stream {
+        MaybeTlsStream::Plain(tcp) => Some(tcp),
+        MaybeTlsStream::Rustls(tls) => Some(tls.get_ref().0),
+        // `MaybeTlsStream` is `#[non_exhaustive]`; any other transport variant
+        // simply yields no addresses rather than failing the connection.
+        _ => None,
+    };
+
+    match tcp {
+        Some(tcp) => (tcp.local_addr().ok(), tcp.peer_addr().ok()),
+        None => (None, None),
+    }
+}

--- a/src/listen/flux.rs
+++ b/src/listen/flux.rs
@@ -13,7 +13,7 @@ use std::{
     path::Path,
     pin::Pin,
     task::{Context, Poll},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::anyhow;
@@ -43,6 +43,7 @@ use crate::{
         flux_response::{ConfigureThresholds, FluxResponse},
         options::{Encoding, Options},
     },
+    listen::connection::{socket_addrs, WebSocketConnectionInfo},
     Deepgram, DeepgramError, Result, Transcription,
 };
 
@@ -225,6 +226,7 @@ impl FluxBuilder<'_> {
 
         let (tx, rx) = mpsc::channel(1);
         let request_id = handle.request_id();
+        let connection_info = handle.connection_info().clone();
         tokio::task::spawn(async move {
             let mut handle = handle;
             let mut tx = tx;
@@ -276,7 +278,11 @@ impl FluxBuilder<'_> {
                 }
             }
         });
-        Ok(FluxStream { rx, request_id })
+        Ok(FluxStream {
+            rx,
+            request_id,
+            connection_info,
+        })
     }
 
     /// A low level interface to the Deepgram Flux websocket API.
@@ -375,6 +381,7 @@ pub struct FluxHandle {
     message_tx: Sender<WsMessage>,
     pub(crate) response_rx: Receiver<Result<FluxResponse>>,
     request_id: Uuid,
+    connection_info: WebSocketConnectionInfo,
 }
 
 impl FluxHandle {
@@ -401,7 +408,9 @@ impl FluxHandle {
             builder.body(())?
         };
 
+        let connect_start = Instant::now();
         let (ws_stream, upgrade_response) = tokio_tungstenite::connect_async(request).await?;
+        let connect_duration = connect_start.elapsed();
 
         let request_id = upgrade_response
             .headers()
@@ -416,6 +425,16 @@ impl FluxHandle {
                 "Received malformed request ID in websocket upgrade headers"
             )))?;
 
+        // Capture socket addresses before the stream is moved into the worker task.
+        let (local_addr, peer_addr) = socket_addrs(ws_stream.get_ref());
+        let connection_info = WebSocketConnectionInfo {
+            request_id,
+            url: url.to_string(),
+            local_addr,
+            peer_addr,
+            connect_duration,
+        };
+
         let (message_tx, message_rx) = mpsc::channel(256);
         let (response_tx, response_rx) = mpsc::channel(256);
 
@@ -425,6 +444,7 @@ impl FluxHandle {
             message_tx,
             response_rx,
             request_id,
+            connection_info,
         })
     }
 
@@ -478,6 +498,15 @@ impl FluxHandle {
 
     pub fn request_id(&self) -> Uuid {
         self.request_id
+    }
+
+    /// Returns metadata describing the established WebSocket connection.
+    ///
+    /// This includes the Deepgram request ID, the final request URL, the local
+    /// and resolved peer socket addresses, and the total connect-plus-upgrade
+    /// duration. Useful for logging or troubleshooting production connectivity.
+    pub fn connection_info(&self) -> &WebSocketConnectionInfo {
+        &self.connection_info
     }
 }
 
@@ -622,6 +651,7 @@ pub struct FluxStream {
     #[pin]
     rx: Receiver<Result<FluxResponse>>,
     request_id: Uuid,
+    connection_info: WebSocketConnectionInfo,
 }
 
 impl Stream for FluxStream {
@@ -640,6 +670,15 @@ impl FluxStream {
     /// or troubleshooting assistance related to a specific request.
     pub fn request_id(&self) -> Uuid {
         self.request_id
+    }
+
+    /// Returns metadata describing the established WebSocket connection.
+    ///
+    /// This includes the Deepgram request ID, the final request URL, the local
+    /// and resolved peer socket addresses, and the total connect-plus-upgrade
+    /// duration. Useful for logging or troubleshooting production connectivity.
+    pub fn connection_info(&self) -> &WebSocketConnectionInfo {
+        &self.connection_info
     }
 }
 

--- a/src/listen/mod.rs
+++ b/src/listen/mod.rs
@@ -1,5 +1,6 @@
 //! Listen module
 
+pub mod connection;
 pub mod flux;
 pub mod rest;
 pub mod websocket;

--- a/src/listen/websocket.rs
+++ b/src/listen/websocket.rs
@@ -15,7 +15,7 @@ use std::{
     path::Path,
     pin::Pin,
     task::{Context, Poll},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::anyhow;
@@ -46,6 +46,7 @@ use crate::{
         options::{Encoding, Endpointing, Options},
         stream_response::StreamResponse,
     },
+    listen::connection::{socket_addrs, WebSocketConnectionInfo},
     Deepgram, DeepgramError, Result, Transcription,
 };
 
@@ -366,6 +367,7 @@ impl WebsocketBuilder<'_> {
         let (tx, rx) = mpsc::channel(1);
         let mut is_done = false;
         let request_id = handle.request_id();
+        let connection_info = handle.connection_info().clone();
         tokio::task::spawn(async move {
             let mut handle = handle;
             let mut tx = tx;
@@ -441,6 +443,7 @@ impl WebsocketBuilder<'_> {
             rx,
             done: false,
             request_id,
+            connection_info,
         })
     }
 
@@ -653,6 +656,7 @@ pub struct WebsocketHandle {
     message_tx: Sender<WsMessage>,
     response_rx: Receiver<Result<StreamResponse>>,
     request_id: Uuid,
+    connection_info: WebSocketConnectionInfo,
 }
 
 impl WebsocketHandle {
@@ -679,7 +683,9 @@ impl WebsocketHandle {
             builder.body(())?
         };
 
+        let connect_start = Instant::now();
         let (ws_stream, upgrade_response) = tokio_tungstenite::connect_async(request).await?;
+        let connect_duration = connect_start.elapsed();
 
         let request_id = upgrade_response
             .headers()
@@ -693,6 +699,16 @@ impl WebsocketHandle {
             .ok_or(DeepgramError::UnexpectedServerResponse(anyhow!(
                 "Received malformed request ID in websocket upgrade headers"
             )))?;
+
+        // Capture socket addresses before the stream is moved into the worker task.
+        let (local_addr, peer_addr) = socket_addrs(ws_stream.get_ref());
+        let connection_info = WebSocketConnectionInfo {
+            request_id,
+            url: url.to_string(),
+            local_addr,
+            peer_addr,
+            connect_duration,
+        };
 
         let (message_tx, message_rx) = mpsc::channel(256);
         let (response_tx, response_rx) = mpsc::channel(256);
@@ -712,6 +728,7 @@ impl WebsocketHandle {
             message_tx,
             response_rx,
             request_id,
+            connection_info,
         })
     }
 
@@ -771,6 +788,15 @@ impl WebsocketHandle {
     pub fn request_id(&self) -> Uuid {
         self.request_id
     }
+
+    /// Returns metadata describing the established WebSocket connection.
+    ///
+    /// This includes the Deepgram request ID, the final request URL, the local
+    /// and resolved peer socket addresses, and the total connect-plus-upgrade
+    /// duration. Useful for logging or troubleshooting production connectivity.
+    pub fn connection_info(&self) -> &WebSocketConnectionInfo {
+        &self.connection_info
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -788,6 +814,7 @@ pub struct TranscriptionStream {
     rx: Receiver<Result<StreamResponse>>,
     done: bool,
     request_id: Uuid,
+    connection_info: WebSocketConnectionInfo,
 }
 
 impl Stream for TranscriptionStream {
@@ -806,6 +833,15 @@ impl TranscriptionStream {
     /// or troubleshooting assistance related to a specific request.
     pub fn request_id(&self) -> Uuid {
         self.request_id
+    }
+
+    /// Returns metadata describing the established WebSocket connection.
+    ///
+    /// This includes the Deepgram request ID, the final request URL, the local
+    /// and resolved peer socket addresses, and the total connect-plus-upgrade
+    /// duration. Useful for logging or troubleshooting production connectivity.
+    pub fn connection_info(&self) -> &WebSocketConnectionInfo {
+        &self.connection_info
     }
 }
 

--- a/tests/connection_info.rs
+++ b/tests/connection_info.rs
@@ -1,0 +1,111 @@
+//! Mock WebSocket server tests verifying that `connection_info()` is populated
+//! and propagated for live speech-to-text and Flux connections.
+//!
+//! Run with: cargo test --test connection_info --features listen
+
+#[cfg(feature = "listen")]
+mod mock {
+    use std::net::SocketAddr;
+
+    use deepgram::Deepgram;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite;
+
+    const FAKE_REQUEST_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+    /// Spin up a local WebSocket server that completes the upgrade (returning a
+    /// `dg-request-id` header) then closes. Returns the address to connect to.
+    async fn mock_server() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+
+            #[allow(clippy::result_large_err)]
+            let callback =
+                |_req: &tungstenite::handshake::server::Request,
+                 mut resp: tungstenite::handshake::server::Response| {
+                    resp.headers_mut()
+                        .insert("dg-request-id", FAKE_REQUEST_ID.parse().unwrap());
+                    Ok(resp)
+                };
+
+            let mut ws = tokio_tungstenite::accept_hdr_async(stream, callback)
+                .await
+                .unwrap();
+
+            futures::SinkExt::close(&mut ws).await.ok();
+        });
+
+        addr
+    }
+
+    fn make_client(addr: SocketAddr) -> Deepgram {
+        let base_url = format!("ws://{}", addr);
+        Deepgram::with_base_url(base_url.as_str()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn stt_handle_exposes_connection_info() {
+        let addr = mock_server().await;
+        let dg = make_client(addr);
+
+        let handle = dg
+            .transcription()
+            .stream_request()
+            .handle()
+            .await
+            .expect("failed to connect to mock server");
+
+        let info = handle.connection_info();
+        assert_eq!(info.request_id.to_string(), FAKE_REQUEST_ID);
+        assert_eq!(info.request_id, handle.request_id());
+        assert_eq!(info.peer_addr, Some(addr));
+        assert!(info.local_addr.is_some(), "local_addr should be captured");
+        assert!(
+            info.url.starts_with("ws://127.0.0.1"),
+            "url should be the final request URL, got {}",
+            info.url
+        );
+    }
+
+    #[tokio::test]
+    async fn stt_stream_propagates_connection_info() {
+        let addr = mock_server().await;
+        let dg = make_client(addr);
+
+        let audio = futures::stream::empty::<Result<bytes::Bytes, std::io::Error>>();
+        let stream = dg
+            .transcription()
+            .stream_request()
+            .stream(audio)
+            .await
+            .expect("failed to connect to mock server");
+
+        let info = stream.connection_info();
+        assert_eq!(info.request_id.to_string(), FAKE_REQUEST_ID);
+        assert_eq!(info.request_id, stream.request_id());
+        assert_eq!(info.peer_addr, Some(addr));
+        assert!(info.local_addr.is_some(), "local_addr should be captured");
+    }
+
+    #[tokio::test]
+    async fn flux_handle_exposes_connection_info() {
+        let addr = mock_server().await;
+        let dg = make_client(addr);
+
+        let handle = dg
+            .transcription()
+            .flux_request()
+            .handle()
+            .await
+            .expect("failed to connect to mock server");
+
+        let info = handle.connection_info();
+        assert_eq!(info.request_id.to_string(), FAKE_REQUEST_ID);
+        assert_eq!(info.request_id, handle.request_id());
+        assert_eq!(info.peer_addr, Some(addr));
+        assert!(info.local_addr.is_some(), "local_addr should be captured");
+    }
+}


### PR DESCRIPTION
## Summary

Exposes connection metadata already available from a successfully established live WebSocket connection, so applications can log connection diagnostics from production traffic and share them when investigating connectivity or latency issues.

A new `connection_info()` accessor is added to both the low-level handle and the high-level stream for live speech-to-text and Flux, returning a `WebSocketConnectionInfo`:

- **request_id** — the Deepgram request ID (parsed from the `dg-request-id` upgrade header)
- **url** — the final request URL, including model/feature query params (auth is sent as a header and is not part of the URL)
- **local_addr / peer_addr** — the local (source) and resolved peer (destination) socket addresses of the underlying TCP connection
- **connect_duration** — total connect-plus-upgrade duration

Socket addresses are captured from the underlying `TcpStream` before the stream is moved into the worker task. Existing `request_id()` methods are unchanged.

## Changes

- `src/listen/connection.rs` (new) — shared `WebSocketConnectionInfo` type + a helper to read socket addresses from `MaybeTlsStream`.
- `src/listen/websocket.rs`, `src/listen/flux.rs` — capture connection info on connect, store on the handle, propagate to the stream, and add `connection_info()` accessors (mirrors the existing `request_id()` pattern).
- `examples/transcription/websocket/connection_diagnostics.rs` (new) — emits a JSONL diagnostics record.
- `tests/connection_info.rs` (new) — mock-server tests covering `connection_info()` on both handles and stream propagation (also exercises the socket-address extraction path over plain `ws://`).

## Compatibility

Additive and non-breaking — new fields/accessors only; `DeepgramError` is untouched; no new dependencies.

## Scope / follow-up

This tier only describes connections that **complete the WebSocket upgrade**. A connection that fails or is cancelled before the upgrade (for example, by a caller-side connect timeout) never produces a `WebSocketConnectionInfo`. Opt-in **per-phase timings** (DNS / TCP connect / TLS handshake / WS upgrade) and cancellation-safe delivery are deferred to a follow-up (Tier 2), gated behind a feature flag.

## Verification

- `cargo build --all-features`
- `cargo clippy --all-features --all-targets` (clean)
- `cargo fmt --check`
- `cargo test --all-features` (all passing, including the new `connection_info` tests)
