### PR TITLE
chore: release 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.0](https://github.com/deepgram/deepgram-rust-sdk/compare/0.10.0...0.11.0)
+## [0.10.1](https://github.com/deepgram/deepgram-rust-sdk/compare/0.10.0...0.10.1)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/deepgram/deepgram-rust-sdk/compare/0.10.0...HEAD)
+## [0.11.0](https://github.com/deepgram/deepgram-rust-sdk/compare/0.10.0...0.11.0)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deepgram"
-version = "0.11.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "audio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deepgram"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "audio",
@@ -1004,11 +1004,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.87"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2424,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2437,23 +2438,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.60"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2461,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2474,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -2496,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.87"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepgram"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Deepgram <developers@deepgram.com>"]
 edition = "2021"
 description = "Community Rust SDK for Deepgram's automated speech recognition APIs."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepgram"
-version = "0.11.0"
+version = "0.10.1"
 authors = ["Deepgram <developers@deepgram.com>"]
 edition = "2021"
 description = "Community Rust SDK for Deepgram's automated speech recognition APIs."


### PR DESCRIPTION
## Summary

Release **0.10.1**. Everything since 0.10.0 is additive. Per Cargo's 0.x semver rules a patch bump is the right signal: `^0.10` users pick it up automatically, and `cargo semver-checks check-release --release-type patch --all-features` against 0.10.0 runs 223 checks with 0 failures (no breaking or minor-level changes).

Includes:
- #170 — Flux STT: `ForceEndTurn`, `TurnInfo.trigger`, per-word timings, worker/close-handshake fixes
- #171 — Flux TTS (`/v2/speak` REST and websocket) in the new `speak::flux` module
- #169 — opt-in connect diagnostics behind the `connect-diagnostics` feature

This PR only:
- bumps `Cargo.toml` / `Cargo.lock` to 0.10.1
- renames the changelog `Unreleased` heading to `0.10.1` with the compare link
- refreshes the `wasm-bindgen` family in `Cargo.lock` (`js-sys 0.3.87` and `wasm-bindgen 0.2.110` are yanked; `wasm-bindgen-futures` pins them, so the family moves together: 7 crates)

## Test plan

Run locally on this exact tree with `RUSTFLAGS`/`RUSTDOCFLAGS="-D warnings"`:
- [x] `cargo fmt --check --all`
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo test --all --all-features` — 141 doctests, 105 unit, integration suites all green
- [x] `cargo doc --workspace --all-features --no-deps`
- [x] `cargo semver-checks check-release --baseline-version 0.10.0 --all-features --release-type patch` — 223 checks pass, 0 fail
- [x] `cargo publish --dry-run` — packages and verifies (106 files)

## After merge

1. Tag the merge commit `0.10.1` (annotated, "Release 0.10.1") and push the tag
2. `cargo publish`
3. `gh release create 0.10.1` with the changelog section (publishing the release triggers the Context7 docs refresh)
